### PR TITLE
BCI base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAG="2.6.3"
-ARG UBI_IMAGE=registry.access.redhat.com/ubi7/ubi-minimal:latest
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
 ARG GO_IMAGE=rancher/hardened-build-base:v1.18.5b7
 
 # Build the project
@@ -16,7 +16,7 @@ RUN git checkout tags/${TAG} -b ${TAG}
 RUN make clean && make build 
 
 # Create the sriov-cni image
-FROM ${UBI_IMAGE}
+FROM ${BCI_IMAGE}
 WORKDIR /
 COPY --from=builder /go/sriov-cni/build/sriov /usr/bin/
 COPY --from=builder /go/sriov-cni/images/entrypoint.sh /


### PR DESCRIPTION
This PR replaces UBI7 with BCI in the final base image. Related to https://github.com/rancher/rke2/issues/3260.