### PR TITLE
Add reviewers to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "rancher/k3s"
 


### PR DESCRIPTION
This adds rancher/k3s to the PRs that dependabot generates.
This contributes to https://github.com/rancher/rke2/issues/4143.
I tested this by running [the dependabot cli](https://github.com/dependabot/cli) locally:
<details>
  <summary>Test Scenario</summary>

```
input:
  job:
    package-manager: docker
    allowed-updates:
      - update-type: all
    source:
      provider: github
      repo: matttrach/image-build-sriov-cni
      directory: /
      commit: b45ce19e068ac6feb8b0a36ca8b9ed6356ac1d88
    credentials-metadata:
      - host: github.com
        type: git_source
  credentials:
    - host: github.com
      password: $LOCAL_GITHUB_ACCESS_TOKEN
      type: git_source
      username: x-access-token
output:
  - type: update_dependency_list
    expect:
      data:
        dependencies: []
        dependency_files:
          - /Dockerfile
  - type: mark_as_processed
    expect:
      data:
        base-commit-sha: b45ce19e068ac6feb8b0a36ca8b9ed6356ac1d88
```

</details>