### PR TITLE
Remove push-manifest from drone and Makefile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
   image: rancher/hardened-build-base:v1.20.7b3
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  - make DRONE_TAG=${DRONE_TAG} image-push
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password
@@ -70,7 +70,7 @@ steps:
   image: rancher/hardened-build-base:v1.20.4b11
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-  - make DRONE_TAG=${DRONE_TAG} image-push image-manifest
+  - make DRONE_TAG=${DRONE_TAG} image-push
   environment:
     DOCKER_PASSWORD:
       from_secret: docker_password

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,6 @@ image-build:
 image-push:
 	docker push $(ORG)/hardened-sriov-cni:$(TAG)-$(ARCH)
 
-.PHONY: image-manifest
-image-manifest:
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend \
-		$(ORG)/hardened-sriov-cni:$(TAG) \
-		$(ORG)/hardened-sriov-cni:$(TAG)-$(ARCH)
-	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push \
-		$(ORG)/hardened-sriov-cni:$(TAG)
-
 .PHONY: image-scan
 image-scan:
 	trivy image --severity $(SEVERITIES) --no-progress --ignore-unfixed $(ORG)/hardened-sriov-cni:$(TAG)


### PR DESCRIPTION
We added the drone pipeline `manifest` to have a multi-arch image, hence we don't need to push a single-arch manifest anymore