### PR TITLE
Bump to upstream version v2.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG="2.7.0"
+ARG TAG=v2.8.0
 ARG COMMIT="14fbf4a4addb9e946698edc7c5ea4cf20fe498e5"
 ARG BCI_IMAGE=registry.suse.com/bci/bci-base
 ARG GO_IMAGE=rancher/hardened-build-base:v1.21.11b3
@@ -9,7 +9,7 @@ RUN set -x && \
     apk --no-cache add \
     git \
     make
-ARG TAG
+ARG TAG=v2.8.0
 RUN git clone --depth=1 https://github.com/k8snetworkplumbingwg/sriov-cni
 WORKDIR sriov-cni
 RUN git fetch --all --tags --prune

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ORG ?= rancher
 TAG ?= ${GITHUB_ACTION_TAG}
 
 ifeq ($(TAG),)
-TAG := v2.7.0$(BUILD_META)
+TAG := v2.8.0$(BUILD_META)
 endif
 
 ifeq (,$(filter %$(BUILD_META),$(TAG)))


### PR DESCRIPTION



<Actions>
    <action id="1eebd83cdf50b6b85f2b9734d8925b1d515c7cf3eb31eadf38a95d63428f28ee">
        <h3>Update upstream version</h3>
        <details id="254db0fb64a77d55007f54b1cfb8c3dc722afb404e3dce28e3b46899bce3aacf">
            <summary>Bump Dockerfile to upstream version v2.8.0</summary>
            <p>changed lines [1 12] of file &#34;/tmp/updatecli/github/rancher/image-build-sriov-cni/Dockerfile&#34;</p>
            <details>
                <summary>v2.8.0</summary>
                <pre>&#xA;Release published on the 2024-05-26 15:48:36 +0000 UTC at the url https://github.com/k8snetworkplumbingwg/sriov-cni/releases/tag/v2.8.0&#xA;&#xA;## What&#39;s Changed&#xD;&#xA;* support build image for arm64 and ppc64le by @cyclinder in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/234&#xD;&#xA;* tidy deploymenmt folder by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/237&#xD;&#xA;* code clean for pkg/utils.go IsValidMACAddress by @yanggangtony in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/238&#xD;&#xA;* Bump golang.org/x/net from 0.0.0-20220802222814-0bcc04d9c69b to 0.7.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/244&#xD;&#xA;* Update readme by @Eoghan1232 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/243&#xD;&#xA;* bump gopkg.in/yaml.v2 by @SalDaniele in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/248&#xD;&#xA;* bump golang version to 1.20 by @yulng in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/245&#xD;&#xA;* Add codeql workflow by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/254&#xD;&#xA;* Bump golangci-lint in Makefile as well by @jiriproX in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/259&#xD;&#xA;* update multus configuration reference link in README by @frbimo in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/262&#xD;&#xA;* Remove unused GODOC from Makefile by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/261&#xD;&#xA;* Enable race detection in unit tests by @AlinaSecret in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/264&#xD;&#xA;* use make lint in the github actions by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/265&#xD;&#xA;* Add support to revert VF trust by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/258&#xD;&#xA;* Workflow Maintenance by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/266&#xD;&#xA;* fix typo in push workflows by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/267&#xD;&#xA;* Add both hardware and nic mac allocation retry by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/239&#xD;&#xA;* Add support for allmulticast flag by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/268&#xD;&#xA;* expose mac address as part of networks-status in pod yaml by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/240&#xD;&#xA;* Revert &#34;Add support for allmulticast flag&#34; by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/272&#xD;&#xA;* Fix mac address verification by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/274&#xD;&#xA;* Delete ConfIFNames parameter by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/269&#xD;&#xA;* Check VF ID existence in Del cmd by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/273&#xD;&#xA;* Remove Dockerfile.rhel7 by @bn222 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/279&#xD;&#xA;* Support vlan Proto by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/277&#xD;&#xA;* Fix checks for vlan parameters by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/281&#xD;&#xA;* Add logging to sriov-cni by @andreaskaris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/276&#xD;&#xA;* Bump golang.org/x/net from 0.8.0 to 0.17.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/284&#xD;&#xA;* Set MAC address after renaming the interface by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/280&#xD;&#xA;* Fix release workflow by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/287&#xD;&#xA;* fix platform in image push release workflow by @adrianchiris in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/288&#xD;&#xA;* Optionally avoid sleeping in `entrypoint.sh` by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/289&#xD;&#xA;* bump go version to 1.21 by @ii2day in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/290&#xD;&#xA;* chore: Add OWNERS file by @killianmuldoon in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/293&#xD;&#xA;* Add SRIOV Operator CI lane by @zeeke in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/282&#xD;&#xA;* Remove interface name from alt name if exist by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/292&#xD;&#xA;* return MTU in results by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/295&#xD;&#xA;* Bump golang.org/x/net from 0.17.0 to 0.23.0 by @dependabot in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/297&#xD;&#xA;* Skip setting vlan when parameter is not present by @mlguerrero12 in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/296&#xD;&#xA;* Fix the cache save by @SchSeba in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/298&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @yanggangtony made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/238&#xD;&#xA;* @dependabot made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/244&#xD;&#xA;* @Eoghan1232 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/243&#xD;&#xA;* @SalDaniele made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/248&#xD;&#xA;* @yulng made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/245&#xD;&#xA;* @jiriproX made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/259&#xD;&#xA;* @frbimo made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/262&#xD;&#xA;* @AlinaSecret made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/264&#xD;&#xA;* @mlguerrero12 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/268&#xD;&#xA;* @bn222 made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/279&#xD;&#xA;* @andreaskaris made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/276&#xD;&#xA;* @ii2day made their first contribution in https://github.com/k8snetworkplumbingwg/sriov-cni/pull/290&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/k8snetworkplumbingwg/sriov-cni/compare/v2.7.0...v2.8.0</pre>
            </details>
        </details>
        <details id="beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0">
            <summary>Bump Makefile to upstream version v2.8.0</summary>
            <p>1 file(s) updated with &#34;TAG := v2.8.0$$(BUILD_META)&#34;:&#xA;&#x9;* Makefile&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

